### PR TITLE
Fix highlight.js initialization timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <title>Prefire - Автоматизация тестирования для iOS</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
-    <script>hljs.highlightAll();</script>
     <style>
         @font-face {
             font-family: 'Roboto', sans-serif;
@@ -390,6 +389,7 @@ class PrefireSnapshotTests: XCTestCase {
         })();
 
         document.addEventListener("DOMContentLoaded", () => {
+            hljs.highlightAll();
             const animatedElements = document.querySelectorAll(".fade-in");
 
             const handleScroll = () => {


### PR DESCRIPTION
## Summary
- call `hljs.highlightAll()` after `DOMContentLoaded` instead of inline in the head

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e50b9ab4883288841b71fb7e71991