### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,12 +88,16 @@
             color: var(--link-color);
         }
         .hero {
-			display: flex;
-			flex-direction: column;
+                        display: flex;
+                        flex-direction: column;
             color: var(--foreground-color);
-			padding: 2rem 1.5rem;
+                        padding: 2rem 1.5rem;
             position: relative;
             z-index: 2;
+        }
+        .hero-icon {
+            max-width: 150px;
+            height: auto;
         }
         .hero h1 {
             font-size: 64px;
@@ -243,12 +247,47 @@
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
         }
         @media screen and (max-width: 768px) {
+            header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            nav {
+                width: 100%;
+                flex-direction: column;
+                align-items: flex-start;
+                margin-top: 0.5rem;
+            }
             .hero {
                 flex-direction: column;
                 align-items: center;
             }
+            .hero h1 {
+                font-size: 40px;
+            }
+            section h2 {
+                font-size: 32px;
+            }
             .hero-buttons {
                 flex-direction: column;
+            }
+            .card-container {
+                flex-direction: column;
+            }
+            .card {
+                margin-bottom: 1rem;
+            }
+            .code-example {
+                flex-direction: column;
+            }
+            .code-image {
+                width: 100%;
+                margin-top: 1rem;
+            }
+            section p, ol {
+                font-size: 20px;
+            }
+            .hero-icon {
+                display: none;
             }
         }
         .fade-in {


### PR DESCRIPTION
## Summary
- adjust header and navigation layout on small screens
- tweak hero, cards, and code blocks to stack vertically on mobile
- reduce font sizes and hide hero icon for phones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e5c29473083288608a4f1661528fe